### PR TITLE
🧪 Add test for DictionaryGroup.closeDict

### DIFF
--- a/app/src/test/java/helium314/keyboard/latin/DictionaryGroupTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/DictionaryGroupTest.kt
@@ -1,0 +1,71 @@
+package helium314.keyboard.latin
+
+import helium314.keyboard.latin.dictionary.Dictionary
+import helium314.keyboard.latin.dictionary.ExpandableBinaryDictionary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.never
+import java.util.Locale
+
+class DictionaryGroupTest {
+
+    @Test
+    fun testCloseDict_MainDict() {
+        val dictGroupClass = Class.forName("helium314.keyboard.latin.DictionaryGroup")
+        val constructor = dictGroupClass.declaredConstructors.first { it.parameterCount == 4 }
+        constructor.isAccessible = true
+
+        val mockMainDict = mock(Dictionary::class.java)
+        val instance = constructor.newInstance(Locale.ENGLISH, mockMainDict, emptyMap<String, ExpandableBinaryDictionary>(), null)
+
+        val closeDictMethod = dictGroupClass.getDeclaredMethod("closeDict", String::class.java)
+        closeDictMethod.isAccessible = true
+
+        closeDictMethod.invoke(instance, Dictionary.TYPE_MAIN)
+
+        verify(mockMainDict).close()
+    }
+
+    @Test
+    fun testCloseDict_SubDict() {
+        val dictGroupClass = Class.forName("helium314.keyboard.latin.DictionaryGroup")
+        val constructor = dictGroupClass.declaredConstructors.first { it.parameterCount == 4 }
+        constructor.isAccessible = true
+
+        val mockSubDict = mock(ExpandableBinaryDictionary::class.java)
+        val subDictsMap = mapOf(Dictionary.TYPE_USER_HISTORY to mockSubDict)
+
+        val instance = constructor.newInstance(Locale.ENGLISH, null, subDictsMap, null)
+
+        val closeDictMethod = dictGroupClass.getDeclaredMethod("closeDict", String::class.java)
+        closeDictMethod.isAccessible = true
+
+        val getSubDictMethod = dictGroupClass.getDeclaredMethod("getSubDict", String::class.java)
+        getSubDictMethod.isAccessible = true
+
+        assertEquals(mockSubDict, getSubDictMethod.invoke(instance, Dictionary.TYPE_USER_HISTORY))
+
+        closeDictMethod.invoke(instance, Dictionary.TYPE_USER_HISTORY)
+
+        verify(mockSubDict).close()
+        assertNull(getSubDictMethod.invoke(instance, Dictionary.TYPE_USER_HISTORY))
+    }
+
+    @Test
+    fun testCloseDict_MissingDict() {
+        val dictGroupClass = Class.forName("helium314.keyboard.latin.DictionaryGroup")
+        val constructor = dictGroupClass.declaredConstructors.first { it.parameterCount == 4 }
+        constructor.isAccessible = true
+
+        val instance = constructor.newInstance(Locale.ENGLISH, null, emptyMap<String, ExpandableBinaryDictionary>(), null)
+
+        val closeDictMethod = dictGroupClass.getDeclaredMethod("closeDict", String::class.java)
+        closeDictMethod.isAccessible = true
+
+        // This should not throw any exceptions
+        closeDictMethod.invoke(instance, "nonexistent_dict_type")
+    }
+}

--- a/app/src/test/java/helium314/keyboard/latin/InputLogicTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/InputLogicTest.kt
@@ -55,7 +55,7 @@ class InputLogicTest {
     private lateinit var latinIME: LatinIME
     private val settingsValues get() = Settings.getValues()
     private val inputLogic get() = latinIME.mInputLogic
-    private val connection: RichInputConnection get() = inputLogic.mConnection
+    private val connection: RichInputConnection get() = inputLogic.connection
     private val composerReader = InputLogic::class.java.getDeclaredField("mWordComposer").apply { isAccessible = true }
     private val composer get() = composerReader.get(inputLogic) as WordComposer
     private val spaceStateReader = InputLogic::class.java.getDeclaredField("mSpaceState").apply { isAccessible = true }
@@ -755,7 +755,7 @@ class InputLogicTest {
 
         if (currentScript != ScriptUtils.SCRIPT_HANGUL // check fails if hangul combiner merges symbols
             && !(codePoint == Constants.CODE_SPACE && oldBefore.lastOrNull() == ' ') // check fails when 2 spaces are converted into a period
-            && !latinIME.mInputLogic.mSuggestedWords.mWillAutoCorrect // autocorrect obviously creates inconsistencies
+            && !latinIME.mInputLogic.suggestedWords.mWillAutoCorrect // autocorrect obviously creates inconsistencies
             ) {
             if (phantomSpaceToInsert.isEmpty())
                 assertEquals(oldBefore + insert, textBeforeCursor)

--- a/app/src/test/java/helium314/keyboard/latin/SuggestTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/SuggestTest.kt
@@ -39,7 +39,7 @@ import kotlin.test.assertEquals
 ])
 class SuggestTest {
     private lateinit var latinIME: LatinIME
-    private val suggest get() = latinIME.mInputLogic.mSuggest
+    private val suggest get() = latinIME.mInputLogic.suggest
 
     // values taken from the string array auto_correction_threshold_mode_indexes
     private val thresholdModest = 0.185f


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `DictionaryFacilitatorImpl.kt:861` (`DictionaryGroup.closeDict`) was not tested. 
📊 **Coverage:** Tests were added for passing `Dictionary.TYPE_MAIN`, a sub dictionary like `Dictionary.TYPE_USER_HISTORY`, and a non-existent dictionary type, using reflection and Mockito.
✨ **Result:** The `closeDict` method of `DictionaryGroup` is now tested.

---
*PR created automatically by Jules for task [15510900159115049386](https://jules.google.com/task/15510900159115049386) started by @LeanBitLab*