### PR TITLE
🧪 Test setCursorPositionWithinWord in WordComposer

### DIFF
--- a/app/src/test/java/helium314/keyboard/latin/InputLogicTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/InputLogicTest.kt
@@ -55,7 +55,7 @@ class InputLogicTest {
     private lateinit var latinIME: LatinIME
     private val settingsValues get() = Settings.getValues()
     private val inputLogic get() = latinIME.mInputLogic
-    private val connection: RichInputConnection get() = inputLogic.mConnection
+    private val connection: RichInputConnection get() = inputLogic.connection
     private val composerReader = InputLogic::class.java.getDeclaredField("mWordComposer").apply { isAccessible = true }
     private val composer get() = composerReader.get(inputLogic) as WordComposer
     private val spaceStateReader = InputLogic::class.java.getDeclaredField("mSpaceState").apply { isAccessible = true }
@@ -755,7 +755,7 @@ class InputLogicTest {
 
         if (currentScript != ScriptUtils.SCRIPT_HANGUL // check fails if hangul combiner merges symbols
             && !(codePoint == Constants.CODE_SPACE && oldBefore.lastOrNull() == ' ') // check fails when 2 spaces are converted into a period
-            && !latinIME.mInputLogic.mSuggestedWords.mWillAutoCorrect // autocorrect obviously creates inconsistencies
+            && !latinIME.mInputLogic.suggestedWords.mWillAutoCorrect // autocorrect obviously creates inconsistencies
             ) {
             if (phantomSpaceToInsert.isEmpty())
                 assertEquals(oldBefore + insert, textBeforeCursor)

--- a/app/src/test/java/helium314/keyboard/latin/SuggestTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/SuggestTest.kt
@@ -39,7 +39,7 @@ import kotlin.test.assertEquals
 ])
 class SuggestTest {
     private lateinit var latinIME: LatinIME
-    private val suggest get() = latinIME.mInputLogic.mSuggest
+    private val suggest get() = latinIME.mInputLogic.suggest
 
     // values taken from the string array auto_correction_threshold_mode_indexes
     private val thresholdModest = 0.185f

--- a/app/src/test/java/helium314/keyboard/latin/WordComposerTest.java
+++ b/app/src/test/java/helium314/keyboard/latin/WordComposerTest.java
@@ -1,0 +1,78 @@
+package helium314.keyboard.latin;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import helium314.keyboard.latin.common.Constants;
+import helium314.keyboard.latin.common.CoordinateUtils;
+import helium314.keyboard.latin.define.DebugFlags;
+
+import java.lang.reflect.Field;
+
+@RunWith(RobolectricTestRunner.class)
+public class WordComposerTest {
+
+    @Test
+    public void testSetCursorPositionWithinWord() throws Exception {
+        final WordComposer wordComposer = new WordComposer();
+
+        // Initial state
+        Field cursorPositionField = WordComposer.class.getDeclaredField("mCursorPositionWithinWord");
+        cursorPositionField.setAccessible(true);
+        assertEquals(0, cursorPositionField.getInt(wordComposer));
+
+        // Set to a new value
+        wordComposer.setCursorPositionWithinWord(5);
+
+        // Verify state is updated via reflection
+        assertEquals(5, cursorPositionField.getInt(wordComposer));
+
+        // Test behavioral effects
+        wordComposer.reset();
+
+        // Create a composing word of size 3
+        int[] codePoints = new int[] { 'a', 'b', 'c' };
+        int[] coordinates = CoordinateUtils.newCoordinateArray(3, Constants.NOT_A_COORDINATE, Constants.NOT_A_COORDINATE);
+        wordComposer.setComposingWord(codePoints, coordinates);
+
+        assertTrue(wordComposer.isComposingWord());
+        assertEquals(3, wordComposer.size());
+
+        // Set cursor to front (0)
+        wordComposer.setCursorPositionWithinWord(0);
+        assertTrue(wordComposer.isCursorInFrontOfComposingWord());
+        assertTrue(wordComposer.isCursorFrontOrMiddleOfComposingWord());
+
+        // Set cursor to middle (1)
+        wordComposer.setCursorPositionWithinWord(1);
+        assertFalse(wordComposer.isCursorInFrontOfComposingWord());
+        assertTrue(wordComposer.isCursorFrontOrMiddleOfComposingWord());
+
+        // Set cursor to end (3)
+        wordComposer.setCursorPositionWithinWord(3);
+        assertFalse(wordComposer.isCursorInFrontOfComposingWord());
+        assertFalse(wordComposer.isCursorFrontOrMiddleOfComposingWord());
+
+        // Test error condition for invalid cursor position
+        boolean originalDebugState = DebugFlags.DEBUG_ENABLED;
+        try {
+            DebugFlags.DEBUG_ENABLED = true;
+            // Set an out-of-bounds cursor position (4 > size 3)
+            wordComposer.setCursorPositionWithinWord(4);
+            try {
+                wordComposer.isCursorFrontOrMiddleOfComposingWord();
+                fail("Should throw RuntimeException for invalid cursor position when DEBUG_ENABLED is true");
+            } catch (RuntimeException e) {
+                // Expected exception
+                assertTrue(e.getMessage().contains("Wrong cursor position"));
+            }
+        } finally {
+            DebugFlags.DEBUG_ENABLED = originalDebugState;
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added unit testing for `setCursorPositionWithinWord` in `WordComposer.java` where none existed previously. Also fixed some compilation errors in Kotlin test files (`InputLogicTest.kt` and `SuggestTest.kt`) related to accessing private fields that now require getters.
📊 **Coverage:** Covered the state-changing effect via reflection (for the private `mCursorPositionWithinWord`), behavior changes related to `isCursorInFrontOfComposingWord` and `isCursorFrontOrMiddleOfComposingWord` in multiple edge cases (front, middle, end of word), and also explicit test for the out-of-bounds error condition when `DEBUG_ENABLED = true`.
✨ **Result:** Improved test coverage and fixed failing Kotlin tests. Codebase reliability and maintainability is increased.

---
*PR created automatically by Jules for task [5127441955598749995](https://jules.google.com/task/5127441955598749995) started by @LeanBitLab*