### PR TITLE
🔒 Fix: Migrate Runtime.exec to ProcessBuilder for secure execution in AboutScreen

### DIFF
--- a/app/src/main/java/helium314/keyboard/settings/screens/AboutScreen.kt
+++ b/app/src/main/java/helium314/keyboard/settings/screens/AboutScreen.kt
@@ -169,7 +169,7 @@ fun createAboutSettings(context: Context) = listOf(
             scope.launch(Dispatchers.IO) {
                 ctx.getActivity()?.contentResolver?.openOutputStream(uri)?.use { os ->
                     os.writer().use { writer ->
-                        val logcat = Runtime.getRuntime().exec("logcat -d -b all *:W").inputStream.use { it.reader().readText() }
+                        val logcat = ProcessBuilder("logcat", "-d", "-b", "all", "*:W").start().inputStream.use { it.reader().readText() }
                         val internal = Log.getLog().joinToString("\n")
                         writer.write(logcat + "\n\n" + internal)
                     }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the use of `Runtime.getRuntime().exec` with a single command string (`logcat -d -b all *:W`).

⚠️ **Risk:** The potential impact if left unfixed is the risk of command injection, which can be possible when relying on the underlying `StringTokenizer` if the command arguments were eventually manipulated by user input or malformed. Although not directly vulnerable here due to hardcoded args, it is an unsafe pattern that flags security analysis.

🛡️ **Solution:** The solution mitigates the risk by using `ProcessBuilder("logcat", "-d", "-b", "all", "*:W")`. This explicitly defines the command and its arguments, circumventing tokenization issues and making the code more robust against injection vulnerabilities.

---
*PR created automatically by Jules for task [5297808077530496987](https://jules.google.com/task/5297808077530496987) started by @LeanBitLab*