### PR TITLE
🧪 Add unit tests for JsonUtils.listToJsonStr

### DIFF
--- a/app/src/test/java/helium314/keyboard/latin/utils/JsonUtilsTest.java
+++ b/app/src/test/java/helium314/keyboard/latin/utils/JsonUtilsTest.java
@@ -1,0 +1,47 @@
+package helium314.keyboard.latin.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class JsonUtilsTest {
+
+    @Test
+    public void testListToJsonStr() {
+        // null list
+        assertEquals("", JsonUtils.listToJsonStr(null));
+
+        // empty list
+        assertEquals("", JsonUtils.listToJsonStr(Collections.emptyList()));
+
+        // list with integers and strings
+        List<Object> list = Arrays.asList(1, "hello", 2, "world");
+        String expected = "[{\"Integer\":1},{\"String\":\"hello\"},{\"Integer\":2},{\"String\":\"world\"}]";
+        assertEquals(expected, JsonUtils.listToJsonStr(list));
+
+        // list with unsupported types (they should be serialized as empty objects)
+        List<Object> listWithUnsupported = Arrays.asList(1, 3.14, "test");
+        String expectedWithUnsupported = "[{\"Integer\":1},{},{\"String\":\"test\"}]";
+        assertEquals(expectedWithUnsupported, JsonUtils.listToJsonStr(listWithUnsupported));
+    }
+
+    @Test
+    public void testJsonStrToList() {
+        // empty or invalid
+        assertTrue(JsonUtils.jsonStrToList("").isEmpty());
+
+        // Test parsing the generated string back
+        List<Object> originalList = Arrays.asList(1, "hello", 2, "world");
+        String json = JsonUtils.listToJsonStr(originalList);
+        List<Object> parsedList = JsonUtils.jsonStrToList(json);
+        assertEquals(originalList, parsedList);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `JsonUtils.listToJsonStr` and `jsonStrToList` serialization functions were missing test coverage.
📊 **Coverage:** Added comprehensive tests in `JsonUtilsTest.java` that evaluate serialization and deserialization symmetry with cases for nulls, empty lists, valid content (`Integer`, `String`), and graceful handling of unsupported type instances.
✨ **Result:** Solidifies expected JSON serialization logic and behavior handling with invalid data, preventing regressions in `JsonUtils`.

---
*PR created automatically by Jules for task [15878131214749696678](https://jules.google.com/task/15878131214749696678) started by @LeanBitLab*