### PR TITLE
🧪 Add test for JsonUtils.jsonStrToList error handling

### DIFF
--- a/app/src/test/java/helium314/keyboard/latin/utils/JsonUtilsTest.java
+++ b/app/src/test/java/helium314/keyboard/latin/utils/JsonUtilsTest.java
@@ -1,18 +1,50 @@
 package helium314.keyboard.latin.utils;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class JsonUtilsTest {
+
+    @Test
+    public void testListToJsonStr() {
+        // null list
+        assertEquals("", JsonUtils.listToJsonStr(null));
+
+        // empty list
+        assertEquals("", JsonUtils.listToJsonStr(Collections.emptyList()));
+
+        // list with integers and strings
+        List<Object> list = Arrays.asList(1, "hello", 2, "world");
+        String expected = "[{\"Integer\":1},{\"String\":\"hello\"},{\"Integer\":2},{\"String\":\"world\"}]";
+        assertEquals(expected, JsonUtils.listToJsonStr(list));
+
+        // list with unsupported types (they should be serialized as empty objects)
+        List<Object> listWithUnsupported = Arrays.asList(1, 3.14, "test");
+        String expectedWithUnsupported = "[{\"Integer\":1},{},{\"String\":\"test\"}]";
+        assertEquals(expectedWithUnsupported, JsonUtils.listToJsonStr(listWithUnsupported));
+    }
+
+    @Test
+    public void testJsonStrToList() {
+        // empty or invalid
+        assertTrue(JsonUtils.jsonStrToList("").isEmpty());
+
+        // Test parsing the generated string back
+        List<Object> originalList = Arrays.asList(1, "hello", 2, "world");
+        String json = JsonUtils.listToJsonStr(originalList);
+        List<Object> parsedList = JsonUtils.jsonStrToList(json);
+        assertEquals(originalList, parsedList);
+    }
 
     @Test
     public void testJsonStrToListValid() {
@@ -35,20 +67,5 @@ public class JsonUtilsTest {
         // 2. Syntax error in property name
         List<Object> result2 = JsonUtils.jsonStrToList("[ { Integer: 123 } ]");
         assertTrue("Expected empty list for JSON with syntax error", result2.isEmpty());
-    }
-
-    @Test
-    public void testListToJsonStr() {
-        // When processing an object of unsupported type (like 45.6, Double),
-        // it still calls writer.beginObject() and writer.endObject(), adding "{}"
-        List<Object> list = Arrays.asList(123, "test", 45.6);
-        String json = JsonUtils.listToJsonStr(list);
-        assertEquals("[{\"Integer\":123},{\"String\":\"test\"},{}]", json);
-    }
-
-    @Test
-    public void testListToJsonStrEmpty() {
-        assertEquals("", JsonUtils.listToJsonStr(null));
-        assertEquals("", JsonUtils.listToJsonStr(Arrays.asList()));
     }
 }

--- a/app/src/test/java/helium314/keyboard/latin/utils/JsonUtilsTest.java
+++ b/app/src/test/java/helium314/keyboard/latin/utils/JsonUtilsTest.java
@@ -1,0 +1,54 @@
+package helium314.keyboard.latin.utils;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+public class JsonUtilsTest {
+
+    @Test
+    public void testJsonStrToListValid() {
+        String json = "[ { \"Integer\": 123 }, { \"String\": \"test\" }, { \"InvalidName\": 456 } ]";
+        List<Object> result = JsonUtils.jsonStrToList(json);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals(123, result.get(0));
+        assertEquals("test", result.get(1));
+    }
+
+    @Test
+    public void testJsonStrToListErrorHandling() {
+        // Test with malformed JSON formats that trigger IOException.
+
+        // 1. Truncated object inside array
+        List<Object> result1 = JsonUtils.jsonStrToList("[ { \"Integer\": 123 ");
+        assertTrue("Expected empty list for truncated JSON", result1.isEmpty());
+
+        // 2. Syntax error in property name
+        List<Object> result2 = JsonUtils.jsonStrToList("[ { Integer: 123 } ]");
+        assertTrue("Expected empty list for JSON with syntax error", result2.isEmpty());
+    }
+
+    @Test
+    public void testListToJsonStr() {
+        // When processing an object of unsupported type (like 45.6, Double),
+        // it still calls writer.beginObject() and writer.endObject(), adding "{}"
+        List<Object> list = Arrays.asList(123, "test", 45.6);
+        String json = JsonUtils.listToJsonStr(list);
+        assertEquals("[{\"Integer\":123},{\"String\":\"test\"},{}]", json);
+    }
+
+    @Test
+    public void testListToJsonStrEmpty() {
+        assertEquals("", JsonUtils.listToJsonStr(null));
+        assertEquals("", JsonUtils.listToJsonStr(Arrays.asList()));
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests to ensure `JsonUtils.jsonStrToList` properly handles `IOException` from `JsonReader` when encountering malformed JSON formats.
📊 **Coverage:** Created a new test class `JsonUtilsTest.java` covering the error handling scenarios as well as successful parsing (`jsonStrToList`) and list serialization (`listToJsonStr`).
✨ **Result:** Validated that the try-catch block securely handles invalid structures like truncated strings or unquoted property names by returning an empty list, improving the test coverage of `JsonUtils` and avoiding crashes.

---
*PR created automatically by Jules for task [12763832632596654909](https://jules.google.com/task/12763832632596654909) started by @LeanBitLab*