### PR TITLE
🧪 Add test for JsonUtils.jsonStrToList

### DIFF
--- a/app/src/test/java/helium314/keyboard/latin/utils/JsonUtilsTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/utils/JsonUtilsTest.kt
@@ -1,0 +1,52 @@
+package helium314.keyboard.latin.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class JsonUtilsTest {
+
+    @Test
+    fun testJsonStrToList_validList() {
+        val jsonStr = "[{\"Integer\": 1}, {\"String\": \"hello\"}, {\"Integer\": 42}]"
+        val list = JsonUtils.jsonStrToList(jsonStr)
+
+        assertEquals(3, list.size)
+        assertEquals(1, list[0])
+        assertEquals("hello", list[1])
+        assertEquals(42, list[2])
+    }
+
+    @Test
+    fun testJsonStrToList_emptyString() {
+        val list = JsonUtils.jsonStrToList("")
+        assertTrue(list.isEmpty())
+    }
+
+    @Test
+    fun testJsonStrToList_emptyArray() {
+        val list = JsonUtils.jsonStrToList("[]")
+        assertTrue(list.isEmpty())
+    }
+
+    @Test
+    fun testJsonStrToList_invalidName() {
+        // Objects with invalid property names should be skipped gracefully.
+        val jsonStr = "[{\"Boolean\": true}, {\"Integer\": 123}]"
+        val list = JsonUtils.jsonStrToList(jsonStr)
+
+        assertEquals(1, list.size)
+        assertEquals(123, list[0])
+    }
+
+    @Test
+    fun testJsonStrToList_malformedJson() {
+        // A malformed JSON should result in returning an empty list without throwing an unhandled exception.
+        val jsonStr = "[malformed"
+        val list = JsonUtils.jsonStrToList(jsonStr)
+        assertTrue(list.isEmpty())
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of unit tests for `JsonUtils.jsonStrToList()`, a utility function that converts a JSON string representation into a `List<Object>`.

📊 **Coverage:** What scenarios are now tested
The new `JsonUtilsTest` covers the following scenarios:
- `testJsonStrToList_validList`: Parsing a valid JSON array of objects correctly.
- `testJsonStrToList_emptyString`: Handling an empty string gracefully.
- `testJsonStrToList_emptyArray`: Handling an empty JSON array `[]` gracefully.
- `testJsonStrToList_invalidName`: Skipping gracefully over unrecognized property names in the JSON objects.
- `testJsonStrToList_malformedJson`: Ensuring that structurally malformed JSON input returns an empty list without throwing an unhandled exception.

✨ **Result:** The improvement in test coverage
The `JsonUtils.jsonStrToList()` method is now fully covered by unit tests, ensuring that future refactoring will not introduce regressions and that standard/edge cases are properly handled.

---
*PR created automatically by Jules for task [1770694567185360950](https://jules.google.com/task/1770694567185360950) started by @LeanBitLab*