### PR TITLE
🧪 [testing improvement] Add tests for getDictionaryFileHeaderOrNull error path

### DIFF
--- a/app/src/test/java/helium314/keyboard/latin/utils/DictionaryInfoUtilsTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/utils/DictionaryInfoUtilsTest.kt
@@ -1,0 +1,51 @@
+package helium314.keyboard.latin.utils
+
+import com.android.inputmethod.latin.utils.BinaryDictionaryUtils
+import helium314.keyboard.latin.makedict.UnsupportedFormatException
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.io.File
+import org.mockito.Mockito
+import org.junit.Before
+import org.junit.After
+import org.mockito.MockedStatic
+
+class DictionaryInfoUtilsTest {
+
+    private lateinit var mockedLog: MockedStatic<helium314.keyboard.latin.utils.Log>
+    private lateinit var mockedBinaryDictionaryUtils: MockedStatic<BinaryDictionaryUtils>
+
+    @Before
+    fun setUp() {
+        mockedLog = Mockito.mockStatic(helium314.keyboard.latin.utils.Log::class.java)
+        mockedBinaryDictionaryUtils = Mockito.mockStatic(BinaryDictionaryUtils::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        mockedLog.close()
+        mockedBinaryDictionaryUtils.close()
+    }
+
+    @Test
+    fun testGetDictionaryFileHeaderOrNull_ioException_returnsNull() {
+        val mockFile = Mockito.mock(File::class.java)
+
+        mockedBinaryDictionaryUtils.`when`<Any> { BinaryDictionaryUtils.getHeader(mockFile) }
+            .thenThrow(java.io.IOException::class.java)
+
+        val result = DictionaryInfoUtils.getDictionaryFileHeaderOrNull(mockFile)
+        assertNull(result)
+    }
+
+    @Test
+    fun testGetDictionaryFileHeaderOrNull_unsupportedFormatException_returnsNull() {
+        val mockFile = Mockito.mock(File::class.java)
+
+        mockedBinaryDictionaryUtils.`when`<Any> { BinaryDictionaryUtils.getHeader(mockFile) }
+            .thenThrow(UnsupportedFormatException::class.java)
+
+        val result = DictionaryInfoUtils.getDictionaryFileHeaderOrNull(mockFile)
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that the error paths (catching `IOException` and `UnsupportedFormatException`) for `DictionaryInfoUtils.getDictionaryFileHeaderOrNull` were untested.
📊 **Coverage:** The scenarios now tested are when the internal call to `BinaryDictionaryUtils.getHeader` throws either an `IOException` or an `UnsupportedFormatException`. 
✨ **Result:** The improvement in test coverage guarantees that `getDictionaryFileHeaderOrNull` will gracefully handle internal dictionary format and IO errors and return `null` instead of crashing.

---
*PR created automatically by Jules for task [2729558021547908781](https://jules.google.com/task/2729558021547908781) started by @LeanBitLab*