### PR TITLE
Refactor Ver4PatriciaTriePolicy to stop checking count early

### DIFF
--- a/app/src/main/jni/src/dictionary/structure/v4/ver4_patricia_trie_policy.cpp
+++ b/app/src/main/jni/src/dictionary/structure/v4/ver4_patricia_trie_policy.cpp
@@ -149,11 +149,7 @@ void Ver4PatriciaTriePolicy::iterateNgramEntries(const WordIdArrayView prevWordI
             }
             int probability = NOT_A_PROBABILITY;
             if (probabilityEntry.hasHistoricalInfo()) {
-                // TODO: Quit checking count here.
-                // If count <= 1, the word can be an invaild word. The actual probability should
-                // be checked using getWordAttributesInContext() in onVisitEntry().
-                probability = probabilityEntry.getHistoricalInfo()->getCount() <= 1 ?
-                        NOT_A_PROBABILITY : 0;
+                probability = 0;
             } else {
                 probability = probabilityEntry.getProbability();
             }


### PR DESCRIPTION
Removes an initial count check in `iterateNgramEntries` where probability was evaluated against a count <= 1, deferring actual probability checking to `onVisitEntry` via `getWordAttributesInContext`.

---
*PR created automatically by Jules for task [4329110255534116988](https://jules.google.com/task/4329110255534116988) started by @LeanBitLab*