### PR TITLE
Fix emoji detection bounds for Mahjong and Joker

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/common/StringUtils.java
+++ b/app/src/main/java/helium314/keyboard/latin/common/StringUtils.java
@@ -498,7 +498,7 @@ public final class StringUtils {
     // very fast check, but there are very few blocks that exclusively contain emojis,
     public static boolean mightBeEmoji(final int c) {
         return (0x200D <= c && c <= 0x2BFF) // unicode blocks from General Punctuation to Miscellaneous Symbols and Arrows
-                || (0x1F104 <= c && c <= 0x1FAFF) // unicode blocks from Mahjong Tiles to Symbols and Pictographs Extended-A
+                || (0x1F000 <= c && c <= 0x1FAFF) // unicode blocks from Mahjong Tiles to Symbols and Pictographs Extended-A
                 || (0xE0000 <= c && c <= 0xE007F) // unicode block Tags
                 || c == 0xFE0F; // variation selector emoji with color
     }

--- a/app/src/test/java/helium314/keyboard/latin/StringUtilsTest.kt
+++ b/app/src/test/java/helium314/keyboard/latin/StringUtilsTest.kt
@@ -166,7 +166,6 @@ class StringUtilsTest {
 
         val brokenDetectionAtStart = listOf("〰️", "〽️", "©️", "®️", "#️⃣", "*️⃣", "0️⃣", "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "㊗️", "㊙️")
         allEmojis.forEach {
-            if (it == "🀄" || it == "🃏") return@forEach // todo: should be fixed, ideally in the regex
             assert(isEmoji(it))
             assert(StringUtils.mightBeEmoji(it.codePointBefore(it.length)))
             if (it !in brokenDetectionAtStart)


### PR DESCRIPTION
Updates the bounds in the fast-path emoji check to include Mahjong Tiles and Playing Cards Unicode blocks, fixing detection for 🀄 and 🃏.

---
*PR created automatically by Jules for task [9368236132567557546](https://jules.google.com/task/9368236132567557546) started by @LeanBitLab*