### PR TITLE
🔒 [security] Disable insecure android:allowBackup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: Apache-2.0 AND GPL-3.0-only
             android:icon="@mipmap/ic_launcher"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
-            android:allowBackup="true"
+            android:allowBackup="false"
             android:defaultToDeviceProtectedStorage="true"
             android:directBootAware="true"
             tools:remove="android:appComponentFactory"


### PR DESCRIPTION
🎯 **What:** Fixed the insecure `android:allowBackup` setting by changing it from `true` to `false` in `app/src/main/AndroidManifest.xml`.

⚠️ **Risk:** When enabled, an attacker with physical access to the device and ADB enabled could potentially extract sensitive user data, such as personal dictionaries and keyboard settings, using the `adb backup` command.

🛡️ **Solution:** Disabled the system-level backup feature. This change does not affect the application's internal manual backup and restore functionality, which is implemented using the Android Storage Access Framework (SAF) in `BackupRestorePreference.kt` and remains fully operational.

---
*PR created automatically by Jules for task [5871912374882396746](https://jules.google.com/task/5871912374882396746) started by @LeanBitLab*